### PR TITLE
Fix bb v3500 compatibility

### DIFF
--- a/gc_duedates/WebRoot/WEB-INF/bb-manifest.xml
+++ b/gc_duedates/WebRoot/WEB-INF/bb-manifest.xml
@@ -5,7 +5,7 @@
     <name value= "Grade Center Due Dates"/>
     <handle value= "gradecenter_duedates"/>
     <description value= "Grade Center Due Dates"/>
-    <version value= "0.9.38"/>
+    <version value= "1.0.0"/>
     
     <requires>
     	<bbversion value="9.1.50119.0"/>
@@ -41,7 +41,7 @@
 		  <link>
             <type value="course_tool"/>
             <!--<type value="gradebook_extension"/>-->
-            <name value="Set Grade Center Due Dates"/>
+            <name value="Grade Center Due Dates"/>
             <url value="gc_duedates.jsp" />
             <description value="Grade Center Due Dates" />
           </link>

--- a/gc_duedates/WebRoot/gc_duedates.jsp
+++ b/gc_duedates/WebRoot/gc_duedates.jsp
@@ -32,7 +32,7 @@ inventoryList is created without vertical scroll bar
 				blackboard.platform.plugin.PlugInUtil,
                                 blackboard.platform.log.LogService,
                                 blackboard.persist.Id,
-                                blackboard.servlet.tags.InlineReceiptTag,
+                                blackboard.platform.servlet.InlineReceiptUtil,
                                 blackboard.platform.gradebook2.GradebookType,
                                 blackboard.platform.gradebook2.impl.GradebookTypeDAO,
                                 idla.gc_duedates.GCDDLog,
@@ -279,7 +279,7 @@ try {
                                                             ReceiptMessage.messageTypeEnum.WARNING);
             } else rm = new ReceiptMessage("Changes Saved", ReceiptMessage.messageTypeEnum.SUCCESS);
             ro.addMessage(rm);
-            request.getSession().setAttribute(InlineReceiptTag.RECEIPT_KEY, ro);
+            request.getSession().setAttribute(InlineReceiptUtil.RECEIPT_KEY, ro);
             // Retrieve the course identifier from the URL and construct formURL for response.sendRedirect(formURL) to itself
             String formURL = requestScope.getIndividualDueDatesURL();
             if ("on".equals(requestScope.getRequest().getParameter("isCommonDueTimeParam"))) {

--- a/gc_duedates/WebRoot/gc_period_duedates.jsp
+++ b/gc_duedates/WebRoot/gc_period_duedates.jsp
@@ -22,7 +22,7 @@ Bug 172334 - is already defined in SimplifiedJSPServlet error
                 blackboard.data.user.*,
                 blackboard.data.ReceiptOptions,
                 blackboard.data.ReceiptMessage,
-                blackboard.servlet.tags.InlineReceiptTag,
+                blackboard.platform.servlet.InlineReceiptUtil,
                 blackboard.platform.log.LogService,
                 blackboard.platform.plugin.PlugInUtil,
                 blackboard.platform.context.Context,
@@ -175,7 +175,7 @@ try {
                                                         ReceiptMessage.messageTypeEnum.WARNING);
         } else rm = new ReceiptMessage("Changes Saved", ReceiptMessage.messageTypeEnum.SUCCESS);
         ro.addMessage(rm);
-        request.getSession().setAttribute(InlineReceiptTag.RECEIPT_KEY, ro);
+        request.getSession().setAttribute(InlineReceiptUtil.RECEIPT_KEY, ro);
         response.sendRedirect(requestScope.getIndividualDueDatesURL());
 
         return;

--- a/gc_duedates/WebRoot/settings.jsp
+++ b/gc_duedates/WebRoot/settings.jsp
@@ -19,6 +19,7 @@ Bug 172334 - is already defined in SimplifiedJSPServlet error
                 blackboard.data.user.*,
                 blackboard.data.ReceiptOptions,
                 blackboard.data.ReceiptMessage,
+                blackboard.platform.servlet.InlineReceiptUtil,
                 blackboard.servlet.tags.InlineReceiptTag,
                 blackboard.platform.log.LogService,
                 blackboard.platform.plugin.PlugInUtil,
@@ -75,7 +76,7 @@ Bug 172334 - is already defined in SimplifiedJSPServlet error
 								ReceiptMessage.messageTypeEnum.WARNING);
 		} else rm = new ReceiptMessage("Changes Saved", ReceiptMessage.messageTypeEnum.SUCCESS);
 		ro.addMessage(rm);
-		request.getSession().setAttribute(InlineReceiptTag.RECEIPT_KEY, ro);
+		request.getSession().setAttribute(InlineReceiptUtil.RECEIPT_KEY, ro);
                 String formURL = "settings.jsp";
 		GCDDLog.logForward(LogService.Verbosity.DEBUG, "response.sendRedirect(), formURL: " + formURL);
 		response.sendRedirect(formURL);


### PR DESCRIPTION
* Bb v3500 compatibility fix - replace servlet.tags.InlineReceiptTag with platform.servlet.InlineReceiptUtil
  for obtaining of RECEIPT_KEY constant.
* Remove "Set" verb from the tool's link name.
* Raise version to 1.0.0 and cancel version suffixing
  with SVN version number due to its unavailability in Git.